### PR TITLE
Add navigation and run report buttons

### DIFF
--- a/src/app/reports/__tests__/page.test.tsx
+++ b/src/app/reports/__tests__/page.test.tsx
@@ -99,6 +99,8 @@ describe('ReportsPage', () => {
       expect(screen.getByText('Landing Page Analysis Reports')).toBeInTheDocument();
     });
 
+    expect(screen.getByRole('link', { name: /back/i })).toHaveAttribute('href', '/');
+
     // Check stats
     expect(screen.getByText('2')).toBeInTheDocument(); // Total reports
     expect(screen.getByText('Total Reports')).toBeInTheDocument();
@@ -116,6 +118,10 @@ describe('ReportsPage', () => {
     // Check links to individual reports
     expect(screen.getByRole('link', { name: /example landing page/i })).toHaveAttribute('href', '/report?id=report-1');
     expect(screen.getByRole('link', { name: /test page/i })).toHaveAttribute('href', '/report?id=report-2');
+
+    // New report buttons should be present
+    const newButtons = screen.getAllByRole('link', { name: /run new report/i });
+    expect(newButtons.length).toBeGreaterThanOrEqual(2);
   });
 
   it('should render error state when API fails', async () => {

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -161,6 +161,19 @@ export default function ReportsPage() {
   return (
     <div className="min-h-screen bg-[var(--color-bg-main)] py-12">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        {/* Back Link */}
+        <div className="mb-6">
+          <Link
+            href="/"
+            className="inline-flex items-center text-blue-400 hover:text-blue-300 transition-colors text-sm font-medium"
+          >
+            <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+            </svg>
+            Back
+          </Link>
+        </div>
+
         {/* Header */}
         <div className="text-center mb-12">
           <h1 className="text-4xl font-bold text-gray-100 mb-4">
@@ -191,6 +204,19 @@ export default function ReportsPage() {
               <div className="text-gray-400">Average Score</div>
             </div>
           </div>
+        </div>
+
+        {/* New Report Button */}
+        <div className="text-center mb-8">
+          <Link
+            href="/"
+            className="inline-flex items-center px-6 py-3 bg-brand-yellow text-gray-900 font-semibold rounded-lg hover:bg-yellow-500 transition-colors"
+          >
+            <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
+            </svg>
+            Run New Report
+          </Link>
         </div>
 
         {/* Reports Grid */}
@@ -225,12 +251,12 @@ export default function ReportsPage() {
           <div className="text-center mt-12">
             <Link
               href="/"
-              className="inline-flex items-center px-8 py-4 bg-brand-yellow text-gray-900 font-semibold rounded-lg hover:bg-yellow-500 transition-colors text-lg"
+              className="inline-flex items-center px-10 py-5 bg-brand-yellow text-gray-900 font-semibold rounded-lg hover:bg-yellow-500 transition-colors text-lg shadow-lg"
             >
               <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6m0 0v6m0-6h6m-6 0H6" />
               </svg>
-              Analyze Another Page
+              Run New Report
             </Link>
           </div>
         )}


### PR DESCRIPTION
## Summary
- add Back link at top of reports page
- insert a new "Run New Report" button above report list
- rename bottom action button to "Run New Report" and enlarge
- update reports page test expectations

## Testing
- `npm test` *(fails: Cannot find module 'lighthouse', exceeded timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68448fde0c248330a911bfc8759e0cff