### PR TITLE
feat: add URL parameter support for auto-analysis

### DIFF
--- a/src/components/UrlInput.tsx
+++ b/src/components/UrlInput.tsx
@@ -1,14 +1,22 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 interface UrlInputProps {
   onAnalyze: (url: string) => void
   isLoading?: boolean
+  initialUrl?: string
 }
 
-export default function UrlInput({ onAnalyze, isLoading = false }: UrlInputProps) {
-  const [url, setUrl] = useState('')
+export default function UrlInput({ onAnalyze, isLoading = false, initialUrl = '' }: UrlInputProps) {
+  const [url, setUrl] = useState(initialUrl)
+
+  // Update url when initialUrl changes
+  useEffect(() => {
+    if (initialUrl) {
+      setUrl(initialUrl)
+    }
+  }, [initialUrl])
   const [error, setError] = useState('')
 
   const validateUrl = (input: string): boolean => {


### PR DESCRIPTION
Users can now pass a URL parameter to pre-fill and auto-trigger analysis.
Example: /?url=https://example.com

- Add useSearchParams hook to read URL parameter from query string
- Update UrlInput component to accept initialUrl prop for pre-filling
- Auto-trigger handleAnalyze when URL parameter is detected
- Wrap component in Suspense for Next.js App Router compatibility