### PR TITLE
Add performance metrics using Browserless API

### DIFF
--- a/src/lib/__tests__/browserless-performance.test.ts
+++ b/src/lib/__tests__/browserless-performance.test.ts
@@ -1,0 +1,250 @@
+import {
+  fetchBrowserlessPerformance,
+  isBrowserlessAvailable,
+} from '../browserless-performance';
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+describe('Browserless Performance API', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+    console.log = jest.fn();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  describe('isBrowserlessAvailable', () => {
+    it('should return true when in production with BLESS_KEY', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.BLESS_KEY = 'test-token';
+      expect(isBrowserlessAvailable()).toBe(true);
+    });
+
+    it('should return false when not in production', () => {
+      process.env.NODE_ENV = 'development';
+      process.env.BLESS_KEY = 'test-token';
+      expect(isBrowserlessAvailable()).toBe(false);
+    });
+
+    it('should return false when BLESS_KEY is missing', () => {
+      process.env.NODE_ENV = 'production';
+      delete process.env.BLESS_KEY;
+      expect(isBrowserlessAvailable()).toBe(false);
+    });
+
+    it('should return false when both conditions are not met', () => {
+      process.env.NODE_ENV = 'development';
+      delete process.env.BLESS_KEY;
+      expect(isBrowserlessAvailable()).toBe(false);
+    });
+  });
+
+  describe('fetchBrowserlessPerformance', () => {
+    const mockLighthouseResponse = {
+      audits: {
+        'largest-contentful-paint': {
+          id: 'largest-contentful-paint',
+          title: 'Largest Contentful Paint',
+          score: 0.95,
+          numericValue: 1200,
+        },
+        'first-contentful-paint': {
+          id: 'first-contentful-paint',
+          title: 'First Contentful Paint',
+          score: 0.98,
+          numericValue: 800,
+        },
+        'cumulative-layout-shift': {
+          id: 'cumulative-layout-shift',
+          title: 'Cumulative Layout Shift',
+          score: 1.0,
+          numericValue: 0.02,
+        },
+        'total-blocking-time': {
+          id: 'total-blocking-time',
+          title: 'Total Blocking Time',
+          score: 0.9,
+          numericValue: 150,
+        },
+        'server-response-time': {
+          id: 'server-response-time',
+          title: 'Server Response Time',
+          score: 1.0,
+          numericValue: 50,
+        },
+        'speed-index': {
+          id: 'speed-index',
+          title: 'Speed Index',
+          score: 0.95,
+          numericValue: 1500,
+        },
+      },
+      categories: {
+        performance: {
+          id: 'performance',
+          title: 'Performance',
+          score: 0.95,
+        },
+      },
+    };
+
+    it('should fetch and parse performance metrics successfully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockLighthouseResponse,
+      });
+
+      const result = await fetchBrowserlessPerformance('https://example.com', {
+        token: 'test-token',
+      });
+
+      expect(result.metrics).toEqual({
+        lcp: 1200,
+        fcp: 800,
+        cls: 0.02,
+        tbt: 150,
+        ttfb: 50,
+        speedIndex: 1500,
+        performanceScore: 95,
+      });
+
+      // Verify fetch was called with correct params
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://production-sfo.browserless.io/performance?token=test-token',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: expect.any(String),
+        })
+      );
+
+      // Verify request body
+      const callArgs = mockFetch.mock.calls[0];
+      const body = JSON.parse(callArgs[1].body);
+      expect(body.url).toBe('https://example.com');
+      expect(body.config.settings.onlyCategories).toContain('performance');
+    });
+
+    it('should handle missing audit values gracefully', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          audits: {
+            'largest-contentful-paint': {
+              id: 'largest-contentful-paint',
+              title: 'LCP',
+              score: 0.9,
+              // numericValue missing
+            },
+          },
+          categories: {
+            performance: {
+              id: 'performance',
+              title: 'Performance',
+              score: 0.85,
+            },
+          },
+        }),
+      });
+
+      const result = await fetchBrowserlessPerformance('https://example.com', {
+        token: 'test-token',
+      });
+
+      // Missing metrics should default to 0
+      expect(result.metrics.lcp).toBe(0);
+      expect(result.metrics.fcp).toBe(0);
+      expect(result.metrics.performanceScore).toBe(85);
+    });
+
+    it('should calculate fallback score when categories are missing', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          audits: {
+            'largest-contentful-paint': { numericValue: 2000 },
+            'first-contentful-paint': { numericValue: 1000 },
+            'cumulative-layout-shift': { numericValue: 0.05 },
+            'total-blocking-time': { numericValue: 200 },
+            'speed-index': { numericValue: 3000 },
+          },
+          // No categories
+        }),
+      });
+
+      const result = await fetchBrowserlessPerformance('https://example.com', {
+        token: 'test-token',
+      });
+
+      // Should have calculated a fallback score
+      expect(result.metrics.performanceScore).toBeGreaterThan(0);
+      expect(result.metrics.performanceScore).toBeLessThanOrEqual(100);
+    });
+
+    it('should throw error on API failure', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        text: async () => 'Internal Server Error',
+      });
+
+      await expect(
+        fetchBrowserlessPerformance('https://example.com', { token: 'test-token' })
+      ).rejects.toThrow('Browserless API error (500): Internal Server Error');
+    });
+
+    it('should handle timeout', async () => {
+      // Mock a fetch that never resolves
+      mockFetch.mockImplementationOnce(() => new Promise(() => {}));
+
+      await expect(
+        fetchBrowserlessPerformance('https://example.com', {
+          token: 'test-token',
+          timeout: 100, // Very short timeout for testing
+        })
+      ).rejects.toThrow('Browserless performance API timeout');
+    });
+
+    it('should round CLS to 3 decimal places', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          audits: {
+            'cumulative-layout-shift': { numericValue: 0.123456789 },
+          },
+          categories: {
+            performance: { score: 0.9 },
+          },
+        }),
+      });
+
+      const result = await fetchBrowserlessPerformance('https://example.com', {
+        token: 'test-token',
+      });
+
+      expect(result.metrics.cls).toBe(0.123);
+    });
+
+    it('should include raw audits in response', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockLighthouseResponse,
+      });
+
+      const result = await fetchBrowserlessPerformance('https://example.com', {
+        token: 'test-token',
+      });
+
+      expect(result.rawAudits).toBeDefined();
+      expect(result.rawAudits!['largest-contentful-paint']).toBeDefined();
+    });
+  });
+});

--- a/src/lib/browserless-performance.ts
+++ b/src/lib/browserless-performance.ts
@@ -1,0 +1,213 @@
+/**
+ * Browserless Performance API Client
+ *
+ * Uses Browserless.io's /performance REST API endpoint to get Lighthouse-based
+ * performance metrics. This is more accurate than manual browser Performance API
+ * measurements.
+ *
+ * @see https://docs.browserless.io/rest-apis/performance
+ */
+
+export interface BrowserlessPerformanceMetrics {
+  lcp: number; // Largest Contentful Paint (ms)
+  fcp: number; // First Contentful Paint (ms)
+  cls: number; // Cumulative Layout Shift
+  tbt: number; // Total Blocking Time (ms)
+  ttfb: number; // Time to First Byte (ms)
+  speedIndex: number; // Speed Index (ms)
+  performanceScore: number; // 0-100 Lighthouse performance score
+}
+
+export interface BrowserlessPerformanceResult {
+  metrics: BrowserlessPerformanceMetrics;
+  rawAudits?: Record<string, any>;
+}
+
+interface LighthouseAudit {
+  id: string;
+  title: string;
+  score: number | null;
+  numericValue?: number;
+  displayValue?: string;
+}
+
+interface LighthouseCategory {
+  id: string;
+  title: string;
+  score: number | null;
+}
+
+interface LighthouseResponse {
+  audits: Record<string, LighthouseAudit>;
+  categories?: Record<string, LighthouseCategory>;
+}
+
+/**
+ * Fetches performance metrics using the Browserless /performance API
+ */
+export async function fetchBrowserlessPerformance(
+  url: string,
+  options: {
+    token: string;
+    timeout?: number;
+  }
+): Promise<BrowserlessPerformanceResult> {
+  const { token, timeout = 60000 } = options;
+
+  const endpoint = `https://production-sfo.browserless.io/performance?token=${token}`;
+
+  console.log('📊 Fetching performance metrics from Browserless API...');
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        url,
+        config: {
+          extends: 'lighthouse:default',
+          settings: {
+            onlyCategories: ['performance'],
+            // Use desktop settings for consistent measurements
+            formFactor: 'desktop',
+            screenEmulation: {
+              mobile: false,
+              width: 1920,
+              height: 1080,
+              deviceScaleFactor: 1,
+            },
+          },
+        },
+      }),
+      signal: controller.signal,
+    });
+
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      throw new Error(`Browserless API error (${response.status}): ${errorText}`);
+    }
+
+    const data: LighthouseResponse = await response.json();
+
+    // Extract metrics from Lighthouse audits
+    const metrics = extractMetricsFromAudits(data);
+
+    console.log('✅ Browserless performance metrics retrieved successfully');
+
+    return {
+      metrics,
+      rawAudits: data.audits,
+    };
+  } catch (error) {
+    clearTimeout(timeoutId);
+
+    if (error instanceof Error && error.name === 'AbortError') {
+      throw new Error(`Browserless performance API timeout after ${timeout}ms`);
+    }
+
+    throw error;
+  }
+}
+
+/**
+ * Extracts standardized metrics from Lighthouse audit response
+ */
+function extractMetricsFromAudits(data: LighthouseResponse): BrowserlessPerformanceMetrics {
+  const audits = data.audits;
+
+  // Helper to safely get numeric value from audit
+  const getNumericValue = (auditId: string): number => {
+    const audit = audits[auditId];
+    if (!audit) return 0;
+    return audit.numericValue ?? 0;
+  };
+
+  // Helper to get score (0-1) and convert to 0-100
+  const getScore = (auditId: string): number => {
+    const audit = audits[auditId];
+    if (!audit || audit.score === null) return 0;
+    return Math.round(audit.score * 100);
+  };
+
+  // Extract Core Web Vitals and performance metrics
+  const lcp = getNumericValue('largest-contentful-paint');
+  const fcp = getNumericValue('first-contentful-paint');
+  const cls = getNumericValue('cumulative-layout-shift');
+  const tbt = getNumericValue('total-blocking-time');
+  const ttfb = getNumericValue('server-response-time');
+  const speedIndex = getNumericValue('speed-index');
+
+  // Get overall performance score from categories if available
+  let performanceScore = 0;
+  if (data.categories?.performance?.score !== null && data.categories?.performance?.score !== undefined) {
+    performanceScore = Math.round(data.categories.performance.score * 100);
+  } else {
+    // Fallback: calculate score based on metrics
+    performanceScore = calculateFallbackScore({ lcp, fcp, cls, tbt, speedIndex });
+  }
+
+  return {
+    lcp: Math.round(lcp),
+    fcp: Math.round(fcp),
+    cls: Math.round(cls * 1000) / 1000, // Round to 3 decimal places
+    tbt: Math.round(tbt),
+    ttfb: Math.round(ttfb),
+    speedIndex: Math.round(speedIndex),
+    performanceScore,
+  };
+}
+
+/**
+ * Fallback score calculation if Lighthouse doesn't return a category score
+ */
+function calculateFallbackScore(metrics: {
+  lcp: number;
+  fcp: number;
+  cls: number;
+  tbt: number;
+  speedIndex: number;
+}): number {
+  let score = 100;
+
+  // LCP scoring (weight: 25%)
+  if (metrics.lcp > 4000) score -= 25;
+  else if (metrics.lcp > 2500) score -= 15;
+  else if (metrics.lcp > 1500) score -= 5;
+
+  // FCP scoring (weight: 15%)
+  if (metrics.fcp > 3000) score -= 15;
+  else if (metrics.fcp > 1800) score -= 10;
+  else if (metrics.fcp > 1000) score -= 3;
+
+  // CLS scoring (weight: 25%)
+  if (metrics.cls > 0.25) score -= 25;
+  else if (metrics.cls > 0.1) score -= 15;
+  else if (metrics.cls > 0.05) score -= 5;
+
+  // TBT scoring (weight: 25%)
+  if (metrics.tbt > 600) score -= 25;
+  else if (metrics.tbt > 300) score -= 15;
+  else if (metrics.tbt > 150) score -= 5;
+
+  // Speed Index scoring (weight: 10%)
+  if (metrics.speedIndex > 5800) score -= 10;
+  else if (metrics.speedIndex > 4300) score -= 5;
+
+  return Math.max(0, Math.round(score));
+}
+
+/**
+ * Checks if Browserless performance API is available
+ */
+export function isBrowserlessAvailable(): boolean {
+  const isProduction = process.env.NODE_ENV === 'production';
+  const hasToken = !!process.env.BLESS_KEY;
+  return isProduction && hasToken;
+}

--- a/src/lib/page-speed-puppeteer.ts
+++ b/src/lib/page-speed-puppeteer.ts
@@ -1,6 +1,11 @@
 import type { Browser } from 'puppeteer-core';
 import { createPuppeteerBrowser } from './puppeteer-config';
 import { getSpeedRecommendations, RecommendationContext } from './recommendations';
+import {
+  fetchBrowserlessPerformance,
+  isBrowserlessAvailable,
+  type BrowserlessPerformanceMetrics,
+} from './browserless-performance';
 
 export interface PageSpeedMetrics {
   lcp: number; // Largest Contentful Paint (ms)
@@ -11,6 +16,8 @@ export interface PageSpeedMetrics {
   loadComplete: number; // Load complete time (ms)
   resourceCount: number; // Total resources loaded
   totalSize: number; // Total page size (bytes)
+  ttfb?: number; // Time to First Byte (ms) - from Browserless API
+  speedIndex?: number; // Speed Index (ms) - from Browserless API
 }
 
 export interface PageSpeedAnalysisResult {
@@ -35,22 +42,95 @@ interface PageSpeedOptions {
 }
 
 export async function analyzePageSpeedPuppeteer(
-  url: string, 
+  url: string,
   options: PageSpeedOptions = {}
 ): Promise<PageSpeedAnalysisResult> {
-  console.log(`🚀 Starting Puppeteer-based page speed analysis for: ${url}`);
+  console.log(`🚀 Starting page speed analysis for: ${url}`);
   const startTime = Date.now();
-  
+
+  // Use Browserless Performance REST API in production for more accurate Lighthouse-based metrics
+  if (isBrowserlessAvailable()) {
+    try {
+      return await analyzeWithBrowserlessAPI(url, options, startTime);
+    } catch (error) {
+      console.warn('⚠️ Browserless Performance API failed, falling back to Puppeteer:', error);
+      // Fall through to Puppeteer-based analysis
+    }
+  }
+
+  // Local development or fallback: use Puppeteer-based analysis
+  return await analyzeWithPuppeteer(url, options, startTime);
+}
+
+/**
+ * Analyze page speed using Browserless /performance REST API (Lighthouse-based)
+ */
+async function analyzeWithBrowserlessAPI(
+  url: string,
+  options: PageSpeedOptions,
+  startTime: number
+): Promise<PageSpeedAnalysisResult> {
+  console.log('🌐 Using Browserless Performance REST API for Lighthouse-based metrics...');
+
+  const token = process.env.BLESS_KEY!;
+  const timeout = options.timeout || 60000;
+
+  const result = await fetchBrowserlessPerformance(url, { token, timeout });
+  const browserlessMetrics = result.metrics;
+
+  // Convert Browserless metrics to our PageSpeedMetrics format
+  const metrics: PageSpeedMetrics = {
+    lcp: browserlessMetrics.lcp,
+    fcp: browserlessMetrics.fcp,
+    cls: browserlessMetrics.cls,
+    tbt: browserlessMetrics.tbt,
+    ttfb: browserlessMetrics.ttfb,
+    speedIndex: browserlessMetrics.speedIndex,
+    // These aren't provided by Lighthouse, so we set reasonable defaults
+    domContentLoaded: browserlessMetrics.fcp, // Approximate
+    loadComplete: browserlessMetrics.lcp, // Approximate
+    resourceCount: 0, // Not provided by Lighthouse performance API
+    totalSize: 0, // Not provided by Lighthouse performance API
+  };
+
+  // Use Lighthouse's score directly (already 0-100)
+  const score = browserlessMetrics.performanceScore;
+
+  // Generate issues and recommendations based on metrics
+  const { issues, recommendations } = generateRecommendations(metrics);
+
+  const loadTime = Date.now() - startTime;
+  console.log(`✅ Browserless Performance API analysis completed in ${loadTime}ms with score: ${score}`);
+
+  return {
+    score,
+    metrics,
+    issues,
+    recommendations,
+    loadTime,
+  };
+}
+
+/**
+ * Analyze page speed using Puppeteer and browser Performance APIs (fallback for local dev)
+ */
+async function analyzeWithPuppeteer(
+  url: string,
+  options: PageSpeedOptions,
+  startTime: number
+): Promise<PageSpeedAnalysisResult> {
+  console.log('📱 Using Puppeteer-based page speed analysis...');
+
   const providedBrowser = options.puppeteer?.browser;
   const shouldCloseBrowser = !providedBrowser;
   let browser: Browser | null = providedBrowser || null;
-  
+
   try {
     const viewport = options.viewport || { width: 1920, height: 1080 };
     const timeout = options.timeout || 60000;
 
     console.log('📱 Launching Puppeteer browser...');
-    
+
     if (!browser) {
       browser = await createPuppeteerBrowser({
         forceBrowserless: options.puppeteer?.forceBrowserless
@@ -65,15 +145,12 @@ export async function analyzePageSpeedPuppeteer(
     await page.coverage.startJSCoverage();
     await page.coverage.startCSSCoverage();
 
-    // Track navigation timing and paint metrics
-    const navigationStart = Date.now();
-    
     console.log('🌐 Navigating to URL and measuring performance...');
-    
+
     // Navigate and collect timing data
-    const response = await page.goto(url, { 
-      waitUntil: 'networkidle2', 
-      timeout 
+    const response = await page.goto(url, {
+      waitUntil: 'networkidle2',
+      timeout
     });
 
     if (!response) {
@@ -87,10 +164,10 @@ export async function analyzePageSpeedPuppeteer(
     const performanceMetrics = await page.evaluate(() => {
       const navigation = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming;
       const paintEntries = performance.getEntriesByType('paint');
-      
+
       let fcp = 0;
       let lcp = 0;
-      
+
       // Get First Contentful Paint
       const fcpEntry = paintEntries.find(entry => entry.name === 'first-contentful-paint');
       if (fcpEntry) {
@@ -136,7 +213,7 @@ export async function analyzePageSpeedPuppeteer(
       const resourceEntries = performance.getEntriesByType('resource') as PerformanceResourceTiming[];
       let totalSize = 0;
       let resourceCount = resourceEntries.length;
-      
+
       // Estimate total size based on transfer sizes where available
       resourceEntries.forEach(resource => {
         if ((resource as any).transferSize) {
@@ -172,15 +249,15 @@ export async function analyzePageSpeedPuppeteer(
     };
 
     console.log('🎯 Calculating performance score and recommendations...');
-    
+
     // Calculate score based on metrics
     const score = calculatePerformanceScore(metrics);
     const { issues, recommendations } = generateRecommendations(metrics);
-    
+
     const loadTime = Date.now() - startTime;
-    
+
     console.log(`✅ Puppeteer page speed analysis completed in ${loadTime}ms with score: ${score}`);
-    
+
     return {
       score,
       metrics,


### PR DESCRIPTION
… metrics

Use Browserless /performance API endpoint in production for more accurate performance metrics. This replaces manual browser Performance API measurements with Lighthouse-based Core Web Vitals (LCP, FCP, CLS, TBT, TTFB, Speed Index).

- Add browserless-performance.ts client for REST API integration
- Update page-speed-puppeteer.ts to use Browserless API in production
- Fall back to Puppeteer-based analysis for local development
- Add comprehensive test coverage for the new integration